### PR TITLE
Remove cache folder from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM haskell:latest
 LABEL application="primo-endpoint" url="http://github.com/NYULibraries/primo-endpoint"
 EXPOSE 8080
 
-VOLUME /cache
 WORKDIR /app
 COPY . /app
 


### PR DESCRIPTION
The cache volume mount will be moved to the OpenShift Deployment resource